### PR TITLE
Add button to buy 3 stacks of Symbol of Kings

### DIFF
--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -110,7 +110,8 @@ addon.registry = {
 	tooltipTitle = "Reagent Tracker Info", 
 	tooltipTextFunction = "TitanPanelReagentTracker_GetTooltipText",
 	savedVariables = {
-		ShowSpellIcons = false, -- variable used throughout the addon to determine whether to show spell or reagent icons
+        ShowSpellIcons = false, -- variable used throughout the addon to determine whether to show spell or reagent icons
+        Buy3StacksSymbolOfKings = false,
 	}
 }
 
@@ -274,6 +275,26 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                         addon:UpdateButton();
                     end
                     L_UIDropDownMenu_AddButton(info, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);
+
+                    -- Github Issue #3
+                    if reagent == "Symbol of Kings" then
+                        -- add button to buy for raid amounts
+                        info2 = {};
+                        info2.text = "Buy 3 stacks of "..reagent
+                        info2.value = Buy3StacksSymbolOfKings
+
+                        info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")
+                        
+                        info2.keepShownOnClick = 1
+                        info2.func = function()
+                            TitanToggleVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings"); -- just a note on           TitanToggleVar. It 'toggles' the variable
+                                                                                            -- between '1' and '', instead of true/false. Can be problematic
+                            addon:UpdateButton();
+                        end
+                        L_UIDropDownMenu_AddButton(info2, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);
+                    end
+                    -- end Github Issue #3
+
                 end
             end
 		end
@@ -335,6 +356,7 @@ function TitanPanelReagentTrackerSpellIcon_Toggle()
 	addon:UpdateButton()
 end
 
+
 --[[
 -- **************************************************************************
 -- NAME : TitanPanelReagentTracker_GetTooltipText()
@@ -395,7 +417,15 @@ function addon:BuyReagents()
                 -- the 8th variable returned by GetItemInfo() is the itemStackCount; the max an item will stack to
                 -- it should never be nil
                 _, _, _, _, _, _, _, desiredCountOfReagent = GetItemInfo(buff.reagentName)    -- get the max a stack of this reagent can be
-            end                                                                                        -- just so that we buy one stack only
+                                                                                                -- just so that we buy one stack only
+                
+                -- Github Issue #3
+                if buff.reagentName == "Symbol of Kings" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings") then
+                   desiredCountOfReagent = desiredCountOfReagent * 3
+                end
+                -- end Github Issue #3
+                
+            end                                                                                        
 
             if debug == true then 
                 if buff.reagentName ~= nil then

--- a/TitanClassicReagentTracker.toc
+++ b/TitanClassicReagentTracker.toc
@@ -1,8 +1,8 @@
 ## Interface: 11304
-## Title: Titan Panel [|cffeda55fReagent Tracker|r] |cff00aa001.0.911304|r
-## Version: 1.0.911304
+## Title: Titan Panel [|cffeda55fReagent Tracker|r] |cff00aa001.0.10.11304|r
+## Version: 1.0.10.11304
 ## Notes: Monitors spell reagents. Fork of Titan Reagent by L'ombra.
-## Author: Farwalker & Klausjones
+## Author: Farwalker & cliaz
 ## Dependencies: TitanClassic
 ## X-Child-Of: TitanClassic
 


### PR DESCRIPTION
Symbol of Kings, to support stocking up on raid-amounts.
Both buttons have to be clicked to buy 3 - the Autobuy Symbol of Kings
button, and the Buy 3 Stacks button. Hardcoded for Symbol of Kings only.
Super Janky.