### PR TITLE
Feature/janky multiple stacks

### DIFF
--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -293,6 +293,7 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                         info2 = {};
                         -- set global variable name appropriately
                         ThreeStackVariableName = ""
+                        info2.value = ""
                         if reagent == "Arcane Powder" then
                             info2.value = Buy3StacksArcanePowder
                             ThreeStackVariableName = "Buy3StacksArcanePowder"

--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -111,7 +111,11 @@ addon.registry = {
 	tooltipTextFunction = "TitanPanelReagentTracker_GetTooltipText",
 	savedVariables = {
         ShowSpellIcons = false, -- variable used throughout the addon to determine whether to show spell or reagent icons
+        Buy3StacksArcanePowder = false,
+        Buy3StacksMapleSeed = false,
+        Buy3StacksSacredCandle = false,
         Buy3StacksSymbolOfKings = false,
+        Buy3StacksWildThornroot = false,
 	}
 }
 
@@ -277,22 +281,55 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                     L_UIDropDownMenu_AddButton(info, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);
 
                     -- Github Issue #3
-                    if reagent == "Symbol of Kings" then
-                        -- add button to buy for raid amounts
+                    -- TODO: rework the addon so that custom ammounts are supported, instead of having this janky workaround
+
+                    -- if the reagent is any of the ones we're buying 3 stacks for
+                    if reagent == "Arcane Powder" or 
+                    reagent == "Maple Seed" or
+                    reagent == "Sacred Candle" or
+                    reagent == "Symbol of Kings" or
+                    reagent == "Wild Thornroot" then
+
+                        -- set global variable name appropriately
+                        3StackVariableName = ""
+                        if reagent == "Arcane Powder" then
+                            info2.value = Buy3StacksArcanePowder
+                            3StackVariableName = "Buy3StacksArcanePowder"
+
+                        else reagent == "Maple Seed" then
+                            info2.value = Buy3StacksMapleSeed
+                            3StackVariableName = "Buy3StacksMapleSeed"
+
+                        else reagent == "Sacred Candle" then
+                            info2.value = Buy3StacksSacredCandle
+                            3StackVariableName = "Buy3StacksSacredCandle"
+
+                        else reagent == "Symbol of Kings" then
+                            info2.value = Buy3StacksSymbolOfKings
+                            3StackVariableName = "Buy3StacksSymbolOfKings"
+
+                        else reagent == "Wild Thornroot" then
+                            info2.value = Buy3StacksWildThornroot
+                            3StackVariableName = "Buy3StacksWildThornroot"
+
+                        -- add button to buy for raid amounts    
                         info2 = {};
                         info2.text = "Buy 3 stacks of "..reagent
-                        info2.value = Buy3StacksSymbolOfKings
+                        --info2.value = Buy3StacksSymbolOfKings
 
-                        info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")
-                        
+                        --info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")
+                        info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, 3StackVariableName)
+
                         info2.keepShownOnClick = 1
                         info2.func = function()
-                            TitanToggleVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings"); -- just a note on           TitanToggleVar. It 'toggles' the variable
+                            --TitanToggleVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings"); -- just a note on TitanToggleVar. It 'toggles' the variable
                                                                                             -- between '1' and '', instead of true/false. Can be problematic
+                            TitanToggleVar(TITAN_REAGENTTRACKER_ID, 3StackVariableName);
                             addon:UpdateButton();
                         end
                         L_UIDropDownMenu_AddButton(info2, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);
                     end
+
                     -- end Github Issue #3
 
                 end

--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -311,8 +311,12 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                         end
                         
                         if debug == true then
-                            DEFAULT_CHAT_FRAME:AddMessage("3 Stack option set to: "..info2.value);
-                            DEFAULT_CHAT_FRAME:AddMessage("(Should only be true or false))");
+                            DEFAULT_CHAT_FRAME:AddMessage("Local var ThreeStackVariableName set to: "..ThreeStackVariableName);
+                            if info2.value ~= nil then
+                                DEFAULT_CHAT_FRAME:AddMessage("Global (saved) var for buying 3 stacks set to: '"..info2.value.."'");
+                            end
+                            DEFAULT_CHAT_FRAME:AddMessage("Global (saved) var for buying 3 stacks set to: ''");
+                            DEFAULT_CHAT_FRAME:AddMessage("Should only be true ('1') or false ('')");
                         end
 
                         -- add button to buy for raid amounts    
@@ -331,7 +335,6 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                         end
                         L_UIDropDownMenu_AddButton(info2, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);
                     end
-
                     -- end Github Issue #3
 
                 end
@@ -459,8 +462,16 @@ function addon:BuyReagents()
                                                                                                 -- just so that we buy one stack only
                 
                 -- Github Issue #3
-                if buff.reagentName == "Symbol of Kings" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings") then
-                   desiredCountOfReagent = desiredCountOfReagent * 3
+           
+                if (
+                (buff.reagentName == "Arcane Powder" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksArcanePowder")) or
+                (buff.reagentName == "Maple Seed" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksMapleSeed")) or
+                (buff.reagentName == "Sacred Candle" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSacredCandle")) or
+                (buff.reagentName == "Symbol of Kings" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")) or
+                (buff.reagentName == "Wild Thornroot" and TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksWildThornroot"))
+                ) then
+                   
+                    desiredCountOfReagent = desiredCountOfReagent * 3
                 end
                 -- end Github Issue #3
                 

--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -290,29 +290,35 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                     reagent == "Symbol of Kings" or
                     reagent == "Wild Thornroot" then
 
+                        info2 = {};
                         -- set global variable name appropriately
                         ThreeStackVariableName = ""
                         if reagent == "Arcane Powder" then
                             info2.value = Buy3StacksArcanePowder
                             ThreeStackVariableName = "Buy3StacksArcanePowder"
-                        else reagent == "Maple Seed" then
+                        elseif reagent == "Maple Seed" then
                             info2.value = Buy3StacksMapleSeed
                             ThreeStackVariableName = "Buy3StacksMapleSeed"
-                        else reagent == "Sacred Candle" then
+                        elseif reagent == "Sacred Candle" then
                             info2.value = Buy3StacksSacredCandle
                             ThreeStackVariableName = "Buy3StacksSacredCandle"
-                        else reagent == "Symbol of Kings" then
+                        elseif reagent == "Symbol of Kings" then
                             info2.value = Buy3StacksSymbolOfKings
                             ThreeStackVariableName = "Buy3StacksSymbolOfKings"
-                        else reagent == "Wild Thornroot" then
+                        elseif reagent == "Wild Thornroot" then
                             info2.value = Buy3StacksWildThornroot
                             ThreeStackVariableName = "Buy3StacksWildThornroot"
                         end
+                        
+                        if debug == true then
+                            DEFAULT_CHAT_FRAME:AddMessage("3 Stack option set to: "..info2.value);
+                            DEFAULT_CHAT_FRAME:AddMessage("(Should only be true or false))");
+                        end
+
                         -- add button to buy for raid amounts    
-                        info2 = {};
                         info2.text = "Buy 3 stacks of "..reagent
                         --info2.value = Buy3StacksSymbolOfKings
-
+                        
                         --info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")
                         info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, ThreeStackVariableName)
 

--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -291,40 +291,36 @@ function TitanPanelRightClickMenu_PrepareReagentTrackerMenu()
                     reagent == "Wild Thornroot" then
 
                         -- set global variable name appropriately
-                        3StackVariableName = ""
+                        ThreeStackVariableName = ""
                         if reagent == "Arcane Powder" then
                             info2.value = Buy3StacksArcanePowder
-                            3StackVariableName = "Buy3StacksArcanePowder"
-
+                            ThreeStackVariableName = "Buy3StacksArcanePowder"
                         else reagent == "Maple Seed" then
                             info2.value = Buy3StacksMapleSeed
-                            3StackVariableName = "Buy3StacksMapleSeed"
-
+                            ThreeStackVariableName = "Buy3StacksMapleSeed"
                         else reagent == "Sacred Candle" then
                             info2.value = Buy3StacksSacredCandle
-                            3StackVariableName = "Buy3StacksSacredCandle"
-
+                            ThreeStackVariableName = "Buy3StacksSacredCandle"
                         else reagent == "Symbol of Kings" then
                             info2.value = Buy3StacksSymbolOfKings
-                            3StackVariableName = "Buy3StacksSymbolOfKings"
-
+                            ThreeStackVariableName = "Buy3StacksSymbolOfKings"
                         else reagent == "Wild Thornroot" then
                             info2.value = Buy3StacksWildThornroot
-                            3StackVariableName = "Buy3StacksWildThornroot"
-
+                            ThreeStackVariableName = "Buy3StacksWildThornroot"
+                        end
                         -- add button to buy for raid amounts    
                         info2 = {};
                         info2.text = "Buy 3 stacks of "..reagent
                         --info2.value = Buy3StacksSymbolOfKings
 
                         --info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings")
-                        info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, 3StackVariableName)
+                        info2.checked = TitanGetVar(TITAN_REAGENTTRACKER_ID, ThreeStackVariableName)
 
                         info2.keepShownOnClick = 1
                         info2.func = function()
                             --TitanToggleVar(TITAN_REAGENTTRACKER_ID, "Buy3StacksSymbolOfKings"); -- just a note on TitanToggleVar. It 'toggles' the variable
                                                                                             -- between '1' and '', instead of true/false. Can be problematic
-                            TitanToggleVar(TITAN_REAGENTTRACKER_ID, 3StackVariableName);
+                            TitanToggleVar(TITAN_REAGENTTRACKER_ID, ThreeStackVariableName);
                             addon:UpdateButton();
                         end
                         L_UIDropDownMenu_AddButton(info2, _G["L_UIDROPDOWNMENU_MENU_LEVEL"]);

--- a/spellData.lua
+++ b/spellData.lua
@@ -42,7 +42,7 @@ addon.spells = {
 				3562,	-- Ironforge
 				3565,	-- Darnassus
 			},
-			reagent = 17031,
+			reagent = 17031,    -- Rune of Teleportation
 		},
 		{	-- Portals
 			spells = {
@@ -53,7 +53,7 @@ addon.spells = {
 				11416,	-- Ironforge
 				11419,	-- Darnassus
 			},
-			reagent = 17032,
+			reagent = 17032,    -- Rune of Portals
 		},
 		{	-- Slow fall
 			spells = {130},
@@ -61,7 +61,7 @@ addon.spells = {
 		},
 		{	-- Arcane Brilliance
 			spells = {23028},
-			reagent = 17020,
+			reagent = 17020,    -- Arcane Powder
 		},
 	},
 	PALADIN = {
@@ -198,7 +198,7 @@ addon.spells = {
 	SHAMAN = {
 		{	-- Reincarnation
 			spells = {20608},
-			reagent = 17030,
+			reagent = 17030,    -- Ankh
 		},
 		{	-- Water breathing
 			spells = {131},


### PR DESCRIPTION
added support for purchasing 3 stacks of:

- Arcane Powder
- Maple Seed
- Sacred Candle
- Symbol of Kings
- Wild Thornroot

Untested in live wow, use with caution. Will not buy too much or delete anything, might just simple not work with those 5 reagents.