### PR TITLE
Wrapped new buying code in nil-value checks

### DIFF
--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -469,14 +469,18 @@ function addon:BuyReagents()
                 _, _, _, _, _, _, _, desiredCountOfReagent = GetItemInfo(buff.reagentName)    -- get the max a stack of this reagent can be
                                                                                                 -- just so that we buy one stack only
                 
-                -- cater for buying multiple stacks of reagents
-                if TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."OneStack") then
-                    desiredCountOfReagent = desiredCountOfReagent * 1 
-                elseif TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."TwoStack") then
-                    desiredCountOfReagent = desiredCountOfReagent * 2
-                elseif TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."ThreeStack") then
-                    desiredCountOfReagent = desiredCountOfReagent * 3
-                end   
+                -- bugfix for Issue #7 from Nihlolino, where GetItemInfo() returns a nil value for max item stack size, and subsequent 
+                -- arithmetic on a nil value fails. This shouldn't need to exist. A reagent can't stack to nil. 
+                if totalCountOfReagent ~= nil and desiredCountOfReagent ~= nil then
+                    -- cater for buying multiple stacks of reagents
+                    if TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."OneStack") then
+                        desiredCountOfReagent = desiredCountOfReagent * 1 
+                    elseif TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."TwoStack") then
+                        desiredCountOfReagent = desiredCountOfReagent * 2
+                    elseif TitanGetVar(TITAN_REAGENTTRACKER_ID, "Reagent"..index.."ThreeStack") then
+                        desiredCountOfReagent = desiredCountOfReagent * 3
+                    end   
+                end
                             
             end                                                                                        
 


### PR DESCRIPTION
Wrapped the recently added code that allows buying of 1, 2 or 3 stacks of reagents in a non-nil check to ensure arithmetic is performed on a valid value. In response to issue #7 

This shouldn't be required, as the GetItemInfo() API function should never return that the max count an item can stack to is nil