### PR TITLE
Helps having correct addon name in function calls

### DIFF
--- a/TitanClassicReagentTracker.lua
+++ b/TitanClassicReagentTracker.lua
@@ -105,7 +105,7 @@ addon.label = text
 
 addon.registry = {
     id = TITAN_REAGENTTRACKER_ID,
-	version = GetAddOnMetadata("TitanReagentTracker", "Version"),   -- the the value of Version variable from the .toc
+	version = GetAddOnMetadata("TitanClassicReagentTracker", "Version"),   -- the the value of Version variable from the .toc
 	menuText = "Reagent Tracker",
 	tooltipTitle = "Reagent Tracker Info",
 	tooltipTextFunction = "TitanPanelReagentTracker_GetTooltipText",


### PR DESCRIPTION
Self evident. Incorrect parameter in function call resulted in failure of addon to register correctly. Unsure why this wasn't an issue in previous versions.

reference: https://github.com/cliaz/Titan-Panel-Classic-Reagent-Tracker/issues/20